### PR TITLE
Fix bug where slurm wasn't being run on the remote executore

### DIFF
--- a/example/cmdline/slurm_funcs.py
+++ b/example/cmdline/slurm_funcs.py
@@ -12,7 +12,7 @@ def echo_1(start: str) -> str:
     return f'echo "1: {start}"'
 
 
-@tag(cache="pickle")
+@tag(cache="pickle", cmdline="slurm")
 @slurm(
     "./workdir",  # chdir and save submit script to here,
     # candidate API:


### PR DESCRIPTION
Add back tag to make slurm run on the remote executor.

Why? because the executor we're using checks for the existence of a tag to know where to submit the function.