### PR TITLE
Changes how the project module is run

### DIFF
--- a/src/molexp/project.py
+++ b/src/molexp/project.py
@@ -49,9 +49,9 @@ def materialize_exp(param: Param, modules: list, materializers: list, root_dir: 
 
 class AllNodesRemoteExecutionManager(DefaultExecutionManager):
     def get_executor_for_task(self, task: TaskImplementation) -> TaskExecutor:
-        """Simple implementation that returns the local executor for single task executions,
+        """Simple implementation that returns the remote executor for all executions.
         :param task: Task to get executor for
-        :return: A local task if this is a "single-node" task, a remote task otherwise
+        :return: Remote executor for all if applicable
         """
         is_single_node_task = len(task.nodes) == 1
         if not is_single_node_task:

--- a/src/molexp/project.py
+++ b/src/molexp/project.py
@@ -1,14 +1,15 @@
-from functools import partial
+# from functools import partial
 from hamilton import driver
-from hamilton.experimental.h_cache import CachingGraphAdapter
+
+# from hamilton.experimental.h_cache import CachingGraphAdapter
 
 from hamilton.plugins import h_experiments
 from hamilton.function_modifiers import value, parameterize, resolve, ResolveAt
 from hamilton.execution.executors import DefaultExecutionManager
 from hamilton.execution import executors
 
-import os
-import json
+# import os
+# import json
 from pathlib import Path
 
 from .param import Param, ParamList
@@ -29,10 +30,24 @@ from hamilton import settings
 #     return tracker.run_id
 
 
+@resolve(
+    when=ResolveAt.CONFIG_AVAILABLE, decorate_with=lambda parameters: parameterize(**parameters)
+)
+def materialize_exp(param: Param, modules: list, materializers: list, root_dir: str) -> str:
+    tracker = h_experiments.ExperimentTracker(param.name, root_dir)
+    dr = (
+        driver.Builder()
+        .with_modules(*modules)
+        .enable_dynamic_execution(allow_experimental_mode=True)
+        .with_adapters(tracker)
+        .build()
+    )
+    dr.materialize(*materializers, inputs=param)
+    return tracker.run_id
+
+
 class Project:
-
     def __init__(self, name: str, work_dir: str | Path = Path.cwd()):
-
         self.name = name
         self._root = Path(work_dir).absolute() / name
 
@@ -41,32 +56,30 @@ class Project:
         return self._root
 
     def materialize(self, param_list: ParamList, materializers: list, *modules: list):
-
-        parameters = {param.name: {"param": value(param)} for param in param_list}
-
-        @resolve(when=ResolveAt.CONFIG_AVAILABLE, decorate_with=lambda: parameterize(**parameters))
-        def materialize_exp(param: Param) -> str:
-            tracker = h_experiments.ExperimentTracker(param.name, self.root)
-            dr = (
-                driver.Builder()
-                .with_modules(*modules)
-                .enable_dynamic_execution(allow_experimental_mode=True)
-                .with_adapters(tracker)
-                .build()
-            )
-            dr.materialize(*materializers, inputs=param)
-            return tracker.run_id
+        config = {
+            "parameters": {
+                param.name: {
+                    "param": value(param),
+                    "modules": value(modules),
+                    "materializers": value(materializers),
+                    "root_dir": value(self.root),
+                }
+                for param in param_list
+            }
+        }
 
         from molexp import project
-        project.materialize_exp = materialize_exp
+
+        # project.materialize_exp = materialize_exp
 
         execution_manager = DefaultExecutionManager(
-            executors.MultiProcessingExecutor(8),
+            executors.SynchronousLocalTaskExecutor(),
             executors.MultiProcessingExecutor(8),
         )
 
         dr = (
             driver.Builder()
+            .with_config(config)
             .with_modules(project)
             .enable_dynamic_execution(allow_experimental_mode=True)
             .with_execution_manager(execution_manager)
@@ -75,5 +88,5 @@ class Project:
         )
 
         dr.execute(
-            final_vars=[name for name in parameters],
+            final_vars=[name for name in config["parameters"]],
         )


### PR DESCRIPTION
1. Moves function outside, and makes proper use of @resolve
2. Changes local task executor to be synchronous - this should be fine to do. The tasks are then executed via the remote one. This at least didn't seem to break when I changed it.